### PR TITLE
Update withRheostat.tsx

### DIFF
--- a/src/hoc/withRheostat.tsx
+++ b/src/hoc/withRheostat.tsx
@@ -63,6 +63,7 @@ const withRheostat = (ChartCompo: any = null) => React.memo((props: RheostatType
     children = null,
     svgData,
     theme,
+    ...chartProps
   } = props;
   let previousHandlePos: number[]; // logging start coords at start of each onPanResponderGrant
   const [handlePos, setHandlePos] = useState(() => inputValues.map((value) => new Animated.Value(
@@ -221,6 +222,7 @@ const withRheostat = (ChartCompo: any = null) => React.memo((props: RheostatType
         data={svgData}
         width={containerSize.width}
         theme={theme}
+        {...chartProps}
       />
       )}
       {handlePos.map((value, idx) => {


### PR DESCRIPTION
Add rest chartprops
Incase if we want to pass some extra props to chart e.g. `yAccessor={({item}) => item.value}` for a custom data